### PR TITLE
[SwipeableFlatList]fix #16685, fix opening rows doesn't close on swipe left a new row.

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableFlatList.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableFlatList.js
@@ -103,6 +103,7 @@ class SwipeableFlatList<ItemT> extends React.Component<Props<ItemT>, State> {
         }}
         onScroll={this._onScroll}
         renderItem={this._renderItem}
+        extraData={this.state.openRowKey}
       />
     );
   }


### PR DESCRIPTION
## Motivation

Fix #16685

According to acc1edd188c16769a6709a8e6feb428203d6235f

## Related PRs
https://github.com/facebook/react-native/pull/16682

## Release Notes
 [JS] [BUGFIX] [SwipeableFlatList] - fix opening rows doesn't close on swipe left a new row.
